### PR TITLE
Add Live Chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ if (typeof window.zdWidget !== "undefined") {
     fields:   {
       1234567890: "some value"
     }
+    chat: true,
+    chat_tags: 'Admin,SalesLoft',
+    chat_department: 'Support'
   });
 ```
 These are the fields taken in:
@@ -80,5 +83,6 @@ These are the fields taken in:
 - `email` - The requester's email address.
 - `category` - (optional) The ID of the help center category to limit your searches to.
 - `fields` - (optional) A object of custom fields to set on the ticket. The key is the ID of the field, and the value is the value.
-
-
+- `chat` - (Defaults to false) Flag turning on Zopim Live Chat.
+- `chat_tags` - (optional) String of comma seperated tags to add to current chat session.
+- `chat_department` - (optional) Default department to direct the visitors current session.

--- a/app/assets/javascripts/widget.js.erb
+++ b/app/assets/javascripts/widget.js.erb
@@ -39,7 +39,8 @@
         name: this.config.name,
         email: this.config.email,
         category: this.config.category,
-        fields: this.config.fields
+        fields: this.config.fields,
+        tags: this.config.tags
       };
       if (addlParams) {
         $.extend(params, addlParams);

--- a/app/assets/javascripts/widget.js.erb
+++ b/app/assets/javascripts/widget.js.erb
@@ -40,7 +40,9 @@
         email: this.config.email,
         category: this.config.category,
         fields: this.config.fields,
-        tags: this.config.tags
+        chat: this.config.chat,
+        chat_department: this.config.chat_department,
+        chat_tags: this.config.chat_tags
       };
       if (addlParams) {
         $.extend(params, addlParams);

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -85,3 +85,9 @@ body {
   text-align: center;
 
 }
+
+.pull-right {
+  a:not(:last-child) {
+    margin-right: 1em;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -49,7 +49,8 @@ body {
 }
 
 .search-results {
-  max-height: 292px;
+  min-height: 422px;
+  max-height: 422px;
   margin-bottom: 15px;
   overflow-y: auto;
 }
@@ -90,4 +91,9 @@ body {
   a:not(:last-child) {
     margin-right: 1em;
   }
+}
+
+#zopim-chat {
+  color: white;
+  font-weight: bold;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ class ApplicationController < ActionController::Base
     session[:name] = params[:name] if params[:name].present?
     session[:email] = params[:email] if params[:email].present?
     session[:fields] = params[:fields] if params[:fields].present?
+    session[:tags] = params[:tags].split(',') if params[:tags].present?
 
     if session[:name].blank? || session[:email].blank?
       response.headers.except! 'X-Frame-Options'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
     session[:name] = params[:name] if params[:name].present?
     session[:email] = params[:email] if params[:email].present?
     session[:fields] = params[:fields] if params[:fields].present?
-    session[:chat] = params[:chat] if params[:chat].present?
+    session[:chat] = ENV['ZOPIM_TOKEN'] && (params[:chat] == 'true') || session[:chat]
     session[:chat_department] = params[:chat_department] if params[:chat_department].present?
     session[:chat_tags] = params[:chat_tags].split(',') if params[:chat_tags].present?
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,9 @@ class ApplicationController < ActionController::Base
     session[:name] = params[:name] if params[:name].present?
     session[:email] = params[:email] if params[:email].present?
     session[:fields] = params[:fields] if params[:fields].present?
-    session[:tags] = params[:tags].split(',') if params[:tags].present?
+    session[:chat] = params[:chat] if params[:chat].present?
+    session[:chat_department] = params[:chat_department] if params[:chat_department].present?
+    session[:chat_tags] = params[:chat_tags].split(',') if params[:chat_tags].present?
 
     if session[:name].blank? || session[:email].blank?
       response.headers.except! 'X-Frame-Options'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
     session[:name] = params[:name] if params[:name].present?
     session[:email] = params[:email] if params[:email].present?
     session[:fields] = params[:fields] if params[:fields].present?
-    session[:chat] = ENV['ZOPIM_TOKEN'] && (params[:chat] == 'true') || session[:chat]
+    session[:chat] = ENV['ZOPIM_TOKEN'] && (params[:chat] == 'true') if params[:chat].present?
     session[:chat_department] = params[:chat_department] if params[:chat_department].present?
     session[:chat_tags] = params[:chat_tags].split(',') if params[:chat_tags].present?
 

--- a/app/views/layouts/application.slim
+++ b/app/views/layouts/application.slim
@@ -18,7 +18,7 @@ html
     = javascript_include_tag "application"
 
 
-  - if ENV['ZOPIM_TOKEN'] && session[:chat]
+  - if session[:chat]
     /! Zopim Live Chat
     javascript:
       window.$zopim || (function(d, s) {

--- a/app/views/layouts/application.slim
+++ b/app/views/layouts/application.slim
@@ -17,45 +17,47 @@ html
 
     = javascript_include_tag "application"
 
-  /! Zopim Live Chat
-  javascript:
-    window.$zopim || (function(d, s) {
-      var z = $zopim = function(c) {
-        z._.push(c)
-      }, $ = z.s = d.createElement(s), e = d.getElementsByTagName(s)[0];
-      z.set = function(o) {
-        z.set._.push(o)
-      };
-      z._ = [];
-      z.set._ = [];
-      $.async = !0;
-      $.setAttribute('charset', 'utf-8');
-      $.src = '//v2.zopim.com/?#{ENV['ZOPIM_TOKEN']}';
-      z.t = +new Date;
-      $.type = 'text/javascript';
-      e.parentNode.insertBefore($, e)
-    })(document, 'script');
 
-    // Zopim Live Chat Widget
-    $zopim(function() {
-      $zopim.livechat.set({
-        language: 'en',
-        name: "#{session[:name]}",
-        email: "#{session[:email]}"
+  - if ENV['ZOPIM_TOKEN'] && session[:chat]
+    /! Zopim Live Chat
+    javascript:
+      window.$zopim || (function(d, s) {
+        var z = $zopim = function(c) {
+          z._.push(c)
+        }, $ = z.s = d.createElement(s), e = d.getElementsByTagName(s)[0];
+        z.set = function(o) {
+          z.set._.push(o)
+        };
+        z._ = [];
+        z.set._ = [];
+        $.async = !0;
+        $.setAttribute('charset', 'utf-8');
+        $.src = '//v2.zopim.com/?#{ENV['ZOPIM_TOKEN']}';
+        z.t = +new Date;
+        $.type = 'text/javascript';
+        e.parentNode.insertBefore($, e)
+      })(document, 'script');
+
+      // Zopim Live Chat Widget
+      $zopim(function() {
+        $zopim.livechat.set({
+          language: 'en',
+          name: "#{session[:name]}",
+          email: "#{session[:email]}",
+        });
+
+        var chat_tags = #{{session[:chat_tags].to_json}};
+        for (var index in chat_tags){
+          $zopim.livechat.addTags(chat_tags[index]);
+        }
+
+        var chat_department = '#{session[:chat_department]}';
+        if(chat_department) {
+          $zopim.livechat.departments.setVisitorDepartment(chat_department);
+        }
+
+        $("#zopim-chat").on("click", function(event) {
+          event.preventDefault();
+          $zopim.livechat.window.show();
+        });
       });
-
-      $zopim.livechat.button.setHideWhenOffline('true');
-
-      var tags = #{{session[:tags].to_json}};
-      for (var index in tags){
-        $zopim.livechat.addTags(tags[index]);
-      }
-      $zopim.livechat.departments.setVisitorDepartment('#{ENV['ZOPIM_DEPARTMENT']}');
-
-      $("#zopim-chat").on("click", function(event) {
-        event.preventDefault();
-        $zopim.livechat.window.show();
-      });
-    });
-
-

--- a/app/views/layouts/application.slim
+++ b/app/views/layouts/application.slim
@@ -44,14 +44,13 @@ html
         email: "#{session[:email]}"
       });
 
-      //$zopim.livechat.addTags("cadence");
-      //if (user.account) {
-      //  $zopim.livechat.addTags(user.account.team_admin ? "Admin" : "User");
-      //  if (user.account.team) {
-      //    $zopim.livechat.addTags(user.account.team.name);
-      //  }
-      //}
-      $zopim.livechat.departments.setVisitorDepartment('Support');
+      $zopim.livechat.button.setHideWhenOffline('true');
+
+      var tags = #{{session[:tags].to_json}};
+      for (var index in tags){
+        $zopim.livechat.addTags(tags[index]);
+      }
+      $zopim.livechat.departments.setVisitorDepartment('#{ENV['ZOPIM_DEPARTMENT']}');
 
       $("#zopim-chat").on("click", function(event) {
         event.preventDefault();

--- a/app/views/layouts/application.slim
+++ b/app/views/layouts/application.slim
@@ -40,8 +40,8 @@ html
     $zopim(function() {
       $zopim.livechat.set({
         language: 'en',
-        name: 'Justin Barber',
-        email: 'justin.barber@salesloft.com'
+        name: "#{session[:name]}",
+        email: "#{session[:email]}"
       });
 
       //$zopim.livechat.addTags("cadence");

--- a/app/views/layouts/application.slim
+++ b/app/views/layouts/application.slim
@@ -16,3 +16,47 @@ html
     .container-fluid: .row = yield
 
     = javascript_include_tag "application"
+
+  /! Zopim Live Chat
+  javascript:
+    window.$zopim || (function(d, s) {
+      var z = $zopim = function(c) {
+        z._.push(c)
+      }, $ = z.s = d.createElement(s), e = d.getElementsByTagName(s)[0];
+      z.set = function(o) {
+        z.set._.push(o)
+      };
+      z._ = [];
+      z.set._ = [];
+      $.async = !0;
+      $.setAttribute('charset', 'utf-8');
+      $.src = '//v2.zopim.com/?#{ENV['ZOPIM_TOKEN']}';
+      z.t = +new Date;
+      $.type = 'text/javascript';
+      e.parentNode.insertBefore($, e)
+    })(document, 'script');
+
+    // Zopim Live Chat Widget
+    $zopim(function() {
+      $zopim.livechat.set({
+        language: 'en',
+        name: 'Justin Barber',
+        email: 'justin.barber@salesloft.com'
+      });
+
+      //$zopim.livechat.addTags("cadence");
+      //if (user.account) {
+      //  $zopim.livechat.addTags(user.account.team_admin ? "Admin" : "User");
+      //  if (user.account.team) {
+      //    $zopim.livechat.addTags(user.account.team.name);
+      //  }
+      //}
+      $zopim.livechat.departments.setVisitorDepartment('Support');
+
+      $("#zopim-chat").on("click", function(event) {
+        event.preventDefault();
+        $zopim.livechat.window.show();
+      });
+    });
+
+

--- a/app/views/layouts/application.slim
+++ b/app/views/layouts/application.slim
@@ -17,7 +17,6 @@ html
 
     = javascript_include_tag "application"
 
-
   - if session[:chat]
     /! Zopim Live Chat
     javascript:
@@ -46,7 +45,7 @@ html
           email: "#{session[:email]}",
         });
 
-        var chat_tags = #{{session[:chat_tags].to_json}};
+        var chat_tags = #{{session.fetch(:chat_tags, []).to_json}};
         for (var index in chat_tags){
           $zopim.livechat.addTags(chat_tags[index]);
         }

--- a/app/views/searches/create.slim
+++ b/app/views/searches/create.slim
@@ -8,6 +8,6 @@ h4.search-heading Here's what we found:
 
 a.btn.btn-default href=new_search_path(params.slice(:category)) Go back
 .pull-right
-  - if ENV['ZOPIM_TOKEN']
+  - if ENV['ZOPIM_TOKEN'] && session[:chat]
     a#zopim-chat.btn.btn-primary href="mailto:#{ENV['ZENDESK_EMAIL']}" Live Chat
   a.btn.btn-primary href=new_ticket_path Send a message instead

--- a/app/views/searches/create.slim
+++ b/app/views/searches/create.slim
@@ -8,5 +8,6 @@ h4.search-heading Here's what we found:
 
 a.btn.btn-default href=new_search_path(params.slice(:category)) Go back
 .pull-right
-  a#zopim-chat.btn.btn-primary href="mailto:#{ENV['ZENDESK_EMAIL']}" Live Chat
+  - if ENV['ZOPIM_TOKEN']
+    a#zopim-chat.btn.btn-primary href="mailto:#{ENV['ZENDESK_EMAIL']}" Live Chat
   a.btn.btn-primary href=new_ticket_path Send a message instead

--- a/app/views/searches/create.slim
+++ b/app/views/searches/create.slim
@@ -7,4 +7,6 @@ h4.search-heading Here's what we found:
       .result-body = truncate strip_tags(result["body"]), length: 100, separator: " ", escape: false
 
 a.btn.btn-default href=new_search_path(params.slice(:category)) Go back
-a.pull-right.btn.btn-primary href=new_ticket_path Send a message instead
+.pull-right
+  a#zopim-chat.btn.btn-primary href="mailto:#{ENV['ZENDESK_EMAIL']}" Live Chat
+  a.btn.btn-primary href=new_ticket_path Send a message instead

--- a/app/views/searches/create.slim
+++ b/app/views/searches/create.slim
@@ -8,6 +8,6 @@ h4.search-heading Here's what we found:
 
 a.btn.btn-default href=new_search_path(params.slice(:category)) Go back
 .pull-right
-  - if ENV['ZOPIM_TOKEN'] && session[:chat]
+  - if session[:chat]
     a#zopim-chat.btn.btn-primary href="mailto:#{ENV['ZENDESK_EMAIL']}" Live Chat
   a.btn.btn-primary href=new_ticket_path Send a message instead


### PR DESCRIPTION
# Feature - Enable Zopim Live Chat in the Zendesk Widget

Widget now displays `Live Chat` button for users with teams of 3 or more after the user has searched Knowledge Base.

<img width="614" alt="screen shot 2015-08-02 at 10 48 43 am" src="https://cloud.githubusercontent.com/assets/503436/9026631/15e46130-3904-11e5-93a3-144190dbe1ee.png">
